### PR TITLE
removed thr url input and put a fixed value

### DIFF
--- a/credentials/DeepSeekApi.credentials.ts
+++ b/credentials/DeepSeekApi.credentials.ts
@@ -23,14 +23,6 @@ export class DeepSeekApi implements ICredentialType {
 			typeOptions: { password: true },
 			required: true,
 			default: '',
-		},
-		{
-			displayName: 'baseUrl',
-			name: 'baseUrl',
-			type: 'string',
-			typeOptions: { password: false },
-			required: true,
-			default: 'https://api.deepseek.com',
 		}
 	];
 
@@ -45,7 +37,7 @@ export class DeepSeekApi implements ICredentialType {
 
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: '={{$credentials.baseUrl}}',
+			baseURL: 'http://host.docker.internal:1234/v1',
 			url: '/models',
 		},
 	};

--- a/nodes/DeepSeek/DeepSeek.node.ts
+++ b/nodes/DeepSeek/DeepSeek.node.ts
@@ -25,7 +25,7 @@ export class DeepSeek implements INodeType {
 		],
 		requestDefaults: {
 			ignoreHttpStatusErrors: true,
-			baseURL: '={{$credentials.baseUrl}}',
+			baseURL: 'http://host.docker.internal:1234/v1',
 		},
 		properties: [
 			{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-deepseek-new",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-deepseek-new",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "description": "A user-friendly DeepSeek AI node, similar to OpenAI, designed to enhance your workflow. npm link: https://www.npmjs.com/package/n8n-nodes-deepseek",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary by Sourcery

Remove the base URL input option and use a fixed URL for DeepSeek API requests.

Enhancements:
- Set DeepSeek base URL to a fixed value instead of relying on user input

Build:
- Bump package version to 1.0.9